### PR TITLE
fixed: multiple client instances in dev

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,8 @@
+import { PrismaClient } from '@prisma/client'
+
+// create only one prisma client instance for development
+const prisma = global.prisma || new PrismaClient()
+
+if (process.env.NODE_ENV !== 'production') global.prisma = prisma
+
+export default prisma

--- a/pages/api/auth/[...nextauth].ts
+++ b/pages/api/auth/[...nextauth].ts
@@ -1,5 +1,5 @@
 import { PrismaAdapter } from '@next-auth/prisma-adapter'
-import { prisma } from 'prisma/index'
+import prisma from 'lib/prisma'
 import NextAuth from 'next-auth'
 import GithubProvider from 'next-auth/providers/github'
 

--- a/pages/api/hello.ts
+++ b/pages/api/hello.ts
@@ -1,7 +1,7 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
 import { User } from '@prisma/client'
 import type { NextApiRequest, NextApiResponse } from 'next'
-import { prisma } from 'prisma/index'
+import prisma from 'lib/prisma'
 
 export default async function handler (req: NextApiRequest, res: NextApiResponse<User[]>) {
   const users: User[] = await prisma.user.findMany({})

--- a/prisma/index.tsx
+++ b/prisma/index.tsx
@@ -1,3 +1,0 @@
-import { PrismaClient } from '@prisma/client'
-
-export const prisma = new PrismaClient()


### PR DESCRIPTION
## Problem:

`warn(prisma-client) There are already 10 instances of Prisma Client actively running.`

## Changes

- [x] Created a new prisma client for development
- [x] Edited prisma client imports in API routes
