### PR TITLE
Adding Locale / Language Switcher component with flags (optional).

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,7 @@ POSTGRES_DATABASE=votadev
 
 ## Prisma
 DATABASE_URL="postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DATABASE}"
+
+# Layout
+# Set locale mode options: text (default), flag, both
+NEXT_PUBLIC_LAYOUT_LOCALE_MODE=text

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,12 +1,14 @@
 import { NavUserOutlet } from 'components/NavUserOutlet'
+import LocaleSwitcher from './LocaleSwitcher'
 import { Logo } from './Logo'
 
 export function Header() {
   return (
     <header className="flex items-center justify-between w-full max-w-4xl px-2 mx-auto my-4">
       <Logo />
-      <div>
+      <div className="flex flex-row items-center justify-around space-x-4">
         <NavUserOutlet />
+        <LocaleSwitcher useFlags={false} />
       </div>
     </header>
   )

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -8,7 +8,7 @@ export function Header() {
       <Logo />
       <div className="flex flex-row items-center justify-around space-x-4">
         <NavUserOutlet />
-        <LocaleSwitcher useFlags={false} />
+        <LocaleSwitcher />
       </div>
     </header>
   )

--- a/components/LocaleSwitcher.tsx
+++ b/components/LocaleSwitcher.tsx
@@ -7,9 +7,8 @@ interface LocaleSwitcherProps {
 }
 
 function LocaleSwitcher({ useFlags = false }: LocaleSwitcherProps) {
-  const { locales, locale } = useRouter()
   const router = useRouter()
-  const { pathname, asPath, query } = router
+  const { locales, locale, pathname, asPath, query } = router
 
   const changeLocale = (nextLocale: string) => {
     router.push({ pathname, query }, asPath, { locale: nextLocale })
@@ -20,13 +19,13 @@ function LocaleSwitcher({ useFlags = false }: LocaleSwitcherProps) {
       <select
         defaultValue={locale}
         onChange={(ev) => changeLocale(ev.target.value)}
-        className="border-2 border-solid border-black text-black text-sm lg:text-xl p-1 uppercase bg-transparent font-semibold hover:opacity-80 transform transition duration-100 hover:scale-105"
+        className="border-2 border-solid border-black text-black text-sm lg:text-xl p-1 uppercase bg-transparent font-semibold hover:opacity-80 transform transition duration-100 hover:scale-105 rounded-md"
       >
         {locales?.map((locale) => (
           <option
             key={locale}
             value={locale}
-            className="flex items-center justify-center space-x-1 bg-transparent text-black font-bold"
+            className="flex items-center justify-center space-x-1 text-black font-bold bg-yellow-js"
           >
             {`${useFlags ? getFlagLocale(locale) : ''} ${locale}`}
           </option>

--- a/components/LocaleSwitcher.tsx
+++ b/components/LocaleSwitcher.tsx
@@ -2,11 +2,9 @@ import { useRouter } from 'next/router'
 
 import { getFlagLocale } from '../helpers/flags'
 
-interface LocaleSwitcherProps {
-  useFlags?: boolean
-}
+const MODE = process.env.NEXT_PUBLIC_LAYOUT_LOCALE_MODE || 'text'
 
-function LocaleSwitcher({ useFlags = false }: LocaleSwitcherProps) {
+function LocaleSwitcher() {
   const router = useRouter()
   const { locales, locale, pathname, asPath, query } = router
 
@@ -27,7 +25,9 @@ function LocaleSwitcher({ useFlags = false }: LocaleSwitcherProps) {
             value={locale}
             className="flex items-center justify-center space-x-1 text-black font-bold bg-yellow-js"
           >
-            {`${useFlags ? getFlagLocale(locale) : ''} ${locale}`}
+            {MODE === 'text' && `${locale}`}
+            {MODE === 'both' && `${getFlagLocale(locale)} ${locale}`}
+            {MODE === 'flag' && `${getFlagLocale(locale)}`}
           </option>
         ))}
       </select>

--- a/components/LocaleSwitcher.tsx
+++ b/components/LocaleSwitcher.tsx
@@ -1,0 +1,38 @@
+import { useRouter } from 'next/router'
+
+import { getFlagLocale } from '../helpers/flags'
+
+interface LocaleSwitcherProps {
+  useFlags?: boolean
+}
+
+function LocaleSwitcher({ useFlags = false }: LocaleSwitcherProps) {
+  const { locales, locale } = useRouter()
+  const router = useRouter()
+  const { pathname, asPath, query } = router
+
+  const changeLocale = (nextLocale: string) => {
+    router.push({ pathname, query }, asPath, { locale: nextLocale })
+  }
+
+  return (
+    <nav>
+      <select
+        defaultValue={locale}
+        onChange={(ev) => changeLocale(ev.target.value)}
+        className="border-2 border-solid border-black text-black text-sm lg:text-xl p-1 uppercase bg-transparent font-semibold hover:opacity-80 transform transition duration-100 hover:scale-105"
+      >
+        {locales?.map((locale) => (
+          <option
+            key={locale}
+            value={locale}
+            className="flex items-center justify-center space-x-1 bg-transparent text-black font-bold"
+          >
+            {`${useFlags ? getFlagLocale(locale) : ''} ${locale}`}
+          </option>
+        ))}
+      </select>
+    </nav>
+  )
+}
+export default LocaleSwitcher

--- a/helpers/flags.ts
+++ b/helpers/flags.ts
@@ -1,7 +1,8 @@
 export const getFlagLocale = (locale: string) => {
   const flagsEmojis: any = {
     es: '🇪🇸 ',
-    en: '🇺🇸/🇬🇧',
+    // en: '🇺🇸',
+    en: '🇬🇧',
   }
   return flagsEmojis[locale] || ''
 }

--- a/helpers/flags.ts
+++ b/helpers/flags.ts
@@ -1,0 +1,7 @@
+export const getFlagLocale = (locale: string) => {
+  const flagsEmojis: any = {
+    es: '🇪🇸 ',
+    en: '🇺🇸/🇬🇧',
+  }
+  return flagsEmojis[locale] || ''
+}


### PR DESCRIPTION
I added a Local or Language Switcher component in Header next to Profile Info or Login Button (if not session).

It looks like this:
* Without flags emoji.
![image](https://user-images.githubusercontent.com/3083587/150909038-fa1cfd88-35f6-41d4-8fae-33244dd3dcb3.png)

*  With flags emoji:
![image](https://user-images.githubusercontent.com/3083587/150909078-12c14c67-fc11-47c7-bc19-f3b73e72d44f.png)

**UPDATE**: the images are old. New changes made with .env variable to control the "layout" of selector (text, flag or both). And removing USA flag for EN.
